### PR TITLE
feature: pull urls for crawl queue from Atom/RSS feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom_syndication"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21fb6a0b39c6517edafe46f8137e53c51742425a4dae1c73ee12264a37ad7541"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "diligent-date-parser",
+ "never",
+ "quick-xml",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +291,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +339,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +380,15 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "diligent-date-parser"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cf7fe294274a222363f84bcb63cdea762979a0443b4cf1f4f8fd17c86b1182"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -680,6 +768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +1005,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -1251,6 +1351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1557,18 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+]
+
+[[package]]
+name = "rss"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaf1331b7fc4edc3c2920819fee1766c27e8d40da593155832db3d6dea64e92"
+dependencies = [
+ "atom_syndication",
+ "derive_builder",
+ "never",
+ "quick-xml",
 ]
 
 [[package]]
@@ -1673,6 +1795,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ron",
+ "rss",
  "serde",
  "sitemap",
  "spyglass-lens",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ nonzero_ext = "0.3.0"
 regex = "1.0"
 reqwest = { version = "0.11", features = ["gzip"] }
 ron = "0.8"
+rss = "2.0.1"
 serde = { version = "1.0", features = ["derive"] }
 sitemap = "0.4.1"
 spyglass-lens = "0.1"

--- a/fixtures/test-atp.ron
+++ b/fixtures/test-atp.ron
@@ -1,0 +1,8 @@
+(
+    version: "1",
+    name: "test_atp",
+    author: "spyglass",
+    description: Some("Spyglass Test Lens"),
+    domains: ["atp.fm"],
+    urls: []
+)

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -232,7 +232,7 @@ impl Netrunner {
         if create_crawl_archive {
             // CRAWL BABY CRAWL
             // Default to max 2 requests per second for a domain.
-            let quota = Quota::per_second(nonzero!(5u32));
+            let quota = Quota::per_second(nonzero!(2u32));
             self.crawl_loop(tmp_storage_path(&self.lens), quota).await?;
         }
 
@@ -363,7 +363,7 @@ impl Netrunner {
                             }
                         }
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -433,7 +433,7 @@ impl Netrunner {
         // Crawl sitemaps & rss feeds
         for info in cache.cache.values().flatten() {
             // Fetch links from RSS feeds
-            self.to_crawl.extend(self.fetch_rss(&info).await);
+            self.to_crawl.extend(self.fetch_rss(info).await);
 
             // Fetch links from sitemap
             if let Some(robot) = &info.robot {
@@ -498,7 +498,7 @@ mod test {
     use tracing_log::LogTracer;
     use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 
-    use crate::{validator::validate_lens, Netrunner, site::SiteInfo};
+    use crate::{site::SiteInfo, validator::validate_lens, Netrunner};
 
     #[tokio::test]
     async fn test_crawl() {
@@ -530,6 +530,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_fetch_rss() {
         let lens = LensConfig {
             author: "test".to_string(),
@@ -539,7 +540,9 @@ mod test {
         };
 
         let netrunner = Netrunner::new(lens);
-        let info = SiteInfo::new("atp.fm").await.expect("unable to create siteinfo");
+        let info = SiteInfo::new("atp.fm")
+            .await
+            .expect("unable to create siteinfo");
         let feed_urls = netrunner.fetch_rss(&info).await;
         assert_eq!(feed_urls.len(), 515);
     }

--- a/src/lib/site.rs
+++ b/src/lib/site.rs
@@ -1,4 +1,4 @@
-use crate::robots::read_robots;
+use crate::cache::read_robots;
 use feedfinder::{detect_feeds, Feed};
 use texting_robots::{get_robots_url, Robot};
 use url::Url;
@@ -13,7 +13,11 @@ pub struct SiteInfo {
 
 impl SiteInfo {
     pub async fn new(domain: &str) -> anyhow::Result<Self> {
-        let domain_url = format!("http://{}", domain);
+        let domain_url = if domain.starts_with("http") {
+            domain.to_string()
+        } else {
+            format!("http://{}", domain)
+        };
 
         let mut feeds = Vec::new();
         let url = Url::parse(&domain_url)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,9 @@ async fn _run_cmd(cli: &mut Cli) -> Result<(), anyhow::Error> {
             // Remove previous urls.txt if any
             if netrunner.url_txt_path().exists() {
                 let _ = std::fs::remove_file(netrunner.url_txt_path());
+                netrunner.state.has_urls = false;
             }
+
             netrunner.crawl(true, false).await
         }
         Commands::Clean => {


### PR DESCRIPTION
On domain rules, check for RSS feeds & use that as an additional way to load URLs into the crawl queue