### PR TITLE
feature: double check 404s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "spyglass-netrunner"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyglass-netrunner"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
 description = "A small CLI utility to help build lenses for spyglass"
 edition = "2021"

--- a/src/lib/crawler.rs
+++ b/src/lib/crawler.rs
@@ -124,25 +124,28 @@ async fn fetch_page(
 
 #[cfg(test)]
 mod test {
-    use std::io;
-    use std::{path::Path, sync::Arc};
+    use super::{handle_crawl, http_client};
     use governor::{Quota, RateLimiter};
     use nonzero_ext::nonzero;
+    use std::io;
+    use std::{path::Path, sync::Arc};
     use tracing_log::LogTracer;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::{fmt, prelude::__tracing_subscriber_SubscriberExt};
     use url::Url;
-    use super::{handle_crawl, http_client};
 
     #[tokio::test]
     #[ignore = "live http request"]
     async fn test_handle_404() {
         // Setup some nice console logging
         let subscriber = tracing_subscriber::registry()
-            .with(EnvFilter::from_default_env()
-                .add_directive("libnetrunner=DEBUG".parse().expect("Invalid log filter")))
+            .with(
+                EnvFilter::from_default_env()
+                    .add_directive("libnetrunner=DEBUG".parse().expect("Invalid log filter")),
+            )
             .with(fmt::Layer::new().with_writer(io::stdout));
-        tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("Unable to set a global subscriber");
         LogTracer::init().expect("Unable to create logger");
 
         let client = http_client();
@@ -151,14 +154,11 @@ mod test {
         let lim = Arc::new(RateLimiter::<String, _, _>::keyed(quota));
 
         // Known to 404 in the web archive, but actually exists.
-        let url = Url::parse("https://developers.home-assistant.io/blog/2020/05/08/logos-custom-integrations")
-            .expect("Invalid URL");
+        let url = Url::parse(
+            "https://developers.home-assistant.io/blog/2020/05/08/logos-custom-integrations",
+        )
+        .expect("Invalid URL");
 
-        handle_crawl(
-            &client,
-            path.to_path_buf(),
-            lim.clone(),
-            &url
-        ).await;
+        handle_crawl(&client, path.to_path_buf(), lim.clone(), &url).await;
     }
 }


### PR DESCRIPTION
The Internet Archive will report 404s for URLs if they don't have it, but the URL may exist at the origin